### PR TITLE
fix(ci): add id-token permission to scheduled Claude workflows

### DIFF
--- a/.github/workflows/claude-scheduled-review.yml
+++ b/.github/workflows/claude-scheduled-review.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/update-asdf-runtimes.yml
+++ b/.github/workflows/update-asdf-runtimes.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Diagnosed recurring GitHub Actions failures in `Update ASDF Runtimes` and `Claude Scheduled Review`.
- Both workflows were failing in `anthropics/claude-code-action@v1` with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`.
- Added the missing `id-token: write` job permission to both workflow files so OIDC token issuance is available.

## Root cause
`claude-code-action` requests a GitHub OIDC token. Without `id-token: write`, Actions does not provide `ACTIONS_ID_TOKEN_REQUEST_URL`, and the action fails after retrying token retrieval.

## Validation
- Reviewed failed logs for runs `25209783713` and `25209708333`; both show the same missing OIDC permission error.
- Ran `./run/test.sh` locally after the change. Suite currently has pre-existing failures/hangs in `apps/brew/test_brew.bats` unrelated to these workflow YAML edits.

_Conversation: https://app.warp.dev/conversation/99376a62-d277-4bed-ae53-fd650195bb5a_
_Run: https://oz.warp.dev/runs/019e0497-a8ef-7014-970e-ec701525c148_
Co-Authored-By: Oz <oz-agent@warp.dev>
_This PR was generated with [Oz](https://warp.dev/oz)._
