### PR TITLE
Disable "Turn Dock hiding on/off" keyboard shortcut (⌥⌘D)

### DIFF
--- a/home/.chezmoiscripts/run_onchange_after_60-macos-defaults.sh
+++ b/home/.chezmoiscripts/run_onchange_after_60-macos-defaults.sh
@@ -56,6 +56,27 @@ defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
 echo "Enabling text replacement globally"
 defaults write -g WebAutomaticTextReplacementEnabled -bool true
 
+echo "Disabling 'Turn Dock hiding on/off' shortcut (Option-Command-D)"
+# Symbolic hotkey 52 = "Turn Dock hiding on/off". Parameters are the default
+# binding (ascii 'd', keycode 2, Cmd+Opt modifiers); enabled=false turns it off.
+defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 52 '
+<dict>
+    <key>enabled</key><false/>
+    <key>value</key><dict>
+        <key>type</key><string>standard</string>
+        <key>parameters</key>
+        <array>
+            <integer>100</integer>
+            <integer>2</integer>
+            <integer>1572864</integer>
+        </array>
+    </dict>
+</dict>'
+
+echo "Reloading symbolic hotkey settings"
+# Makes the hotkey change take effect without logging out.
+/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u 2>/dev/null || true
+
 echo "==> macOS: Dock and Spaces"
 
 echo "Clearing persistent apps from Dock"

--- a/home/.chezmoiscripts/run_onchange_after_60-macos-defaults.sh
+++ b/home/.chezmoiscripts/run_onchange_after_60-macos-defaults.sh
@@ -74,7 +74,11 @@ defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 52 '
 </dict>'
 
 echo "Reloading symbolic hotkey settings"
-# Makes the hotkey change take effect without logging out.
+# Makes the hotkey change take effect without logging out. activateSettings is
+# part of a private Apple framework (SystemAdministration) with no public API
+# contract, so it may move or disappear in any macOS release. The `|| true`
+# keeps that from breaking the script; worst case the change waits for the
+# next logout/restart to apply.
 /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u 2>/dev/null || true
 
 echo "==> macOS: Dock and Spaces"


### PR DESCRIPTION
## Summary

Answers the question "can we turn off the Turn Dock hiding on/off shortcut programmatically?" — yes. That shortcut is macOS **symbolic hotkey ID 52**, stored in `~/Library/Preferences/com.apple.symbolichotkeys.plist`, and it can be disabled with `defaults write`.

## Changes

- Added a `defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 52 ...` entry to `home/.chezmoiscripts/run_onchange_after_60-macos-defaults.sh` that sets `enabled=false` while preserving the default ⌥⌘D binding parameters (ascii `d` = 100, keycode 2, Cmd+Opt modifier mask 1572864).
- Added a call to `activateSettings -u` (SystemAdministration private framework) so the hotkey change takes effect immediately without logging out; it is guarded with `|| true` in case Apple moves/removes the binary in a future macOS release.

## Notes

- The `-dict-add` approach only touches hotkey 52, leaving all other symbolic hotkeys untouched.
- Since the script is a chezmoi `run_onchange` script, it will re-run on the next `chezmoi apply` after this change lands.
- Verified with `bash -n` (this session runs on Linux, so the `defaults` call itself couldn't be executed here — worth confirming the checkbox unchecks in System Settings after the next `chezmoi apply`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mEaLN2tNeoC944d8YHWHs

---
_Generated by [Claude Code](https://claude.ai/code/session_018mEaLN2tNeoC944d8YHWHs)_