### PR TITLE
run Obsidian Headless Sync continuously

### DIFF
--- a/docs/apps-notes.md
+++ b/docs/apps-notes.md
@@ -41,13 +41,22 @@ cp mailmate/Motherbox.plist /Applications/MailMate.app/Contents/Resources/KeyBin
 
 ## Obsidian
 
-Set up headless sync:
+`obsidian-headless` is installed through the managed mise config. On the
+personal Mac mini, it is the only process that connects `~/Notes/Memex` to
+Obsidian Sync. The first Motherbox apply installs the CLI and loads the
+LaunchAgent; it will retry until you complete the one-time login and vault
+setup:
 
 ```bash
-npm install -g obsidian-headless
-ob login
-ob sync-setup --vault {Vault name} --path ~/Notes/{Vault name}
+mise exec -- ob login
+mise exec -- ob sync-setup --vault Memex --path ~/Notes/Memex
 ```
+
+Motherbox starts `ob sync --continuous` at login and launchd keeps it running.
+The runner enforces bidirectional sync with configuration sync disabled. Obsidian
+Desktop may open the same folder, but disconnect its remote vault and keep its
+Sync core plugin disabled on the Mini so only Headless Sync talks to the remote
+vault.
 
 ## OpenSCAD
 

--- a/docs/apps-notes.md
+++ b/docs/apps-notes.md
@@ -53,10 +53,9 @@ ob sync-setup --vault Memex --path ~/Notes/Memex
 ```
 
 Motherbox starts `ob sync --continuous` at login and launchd keeps it running.
-The runner enforces bidirectional sync with configuration sync disabled. Obsidian
-Desktop may open the same folder, but disconnect its remote vault and keep its
-Sync core plugin disabled on the Mini so only Headless Sync talks to the remote
-vault.
+Obsidian Desktop may open the same folder, but disconnect its remote vault and
+keep its Sync core plugin disabled on the Mini so only Headless Sync talks to
+the remote vault.
 
 ## OpenSCAD
 

--- a/docs/apps-notes.md
+++ b/docs/apps-notes.md
@@ -48,8 +48,8 @@ LaunchAgent; it will retry until you complete the one-time login and vault
 setup:
 
 ```bash
-mise exec -- ob login
-mise exec -- ob sync-setup --vault Memex --path ~/Notes/Memex
+ob login
+ob sync-setup --vault Memex --path ~/Notes/Memex
 ```
 
 Motherbox starts `ob sync --continuous` at login and launchd keeps it running.

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -9,6 +9,7 @@ README.md
 # Machine-local secrets, sourced by ~/.zshenv
 .config/zsh/env.local.zsh
 
+# Continuous Obsidian Sync runs only on the personal Mac mini.
 {{ if not (and (eq .profile "personal") (eq .machine "mini")) }}
 Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist
 {{ end }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -9,7 +9,8 @@ README.md
 # Machine-local secrets, sourced by ~/.zshenv
 .config/zsh/env.local.zsh
 
-# Continuous Obsidian Sync runs only on the personal Mac mini.
+# Plists in ~/Library/LaunchAgents can load at login. Omit this RunAtLoad and
+# KeepAlive job entirely where continuous Obsidian Sync must not run.
 {{ if not (and (eq .profile "personal") (eq .machine "mini")) }}
 Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist
 {{ end }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -8,9 +8,3 @@ README.md
 
 # Machine-local secrets, sourced by ~/.zshenv
 .config/zsh/env.local.zsh
-
-# Plists in ~/Library/LaunchAgents can load at login. Omit this RunAtLoad and
-# KeepAlive job entirely where continuous Obsidian Sync must not run.
-{{ if not (and (eq .profile "personal") (eq .machine "mini")) }}
-Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist
-{{ end }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -8,3 +8,7 @@ README.md
 
 # Machine-local secrets, sourced by ~/.zshenv
 .config/zsh/env.local.zsh
+
+{{ if not (and (eq .profile "personal") (eq .machine "mini")) }}
+Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist
+{{ end }}

--- a/home/.chezmoiscripts/run_onchange_after_50-launchagents.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_50-launchagents.sh.tmpl
@@ -13,4 +13,9 @@
 # Script hash: {{ include (joinPath .chezmoi.workingTree "scripts/utils/launchagents.sh") | sha256sum }}
 set -euo pipefail
 
-"$CHEZMOI_WORKING_TREE/scripts/utils/launchagents.sh"
+labels=(net.aaroncurry.motherbox.nightly-maintenance)
+{{ if and (eq .profile "personal") (eq .machine "mini") }}
+labels+=(net.aaroncurry.motherbox.obsidian-sync)
+{{ end }}
+
+"$CHEZMOI_WORKING_TREE/scripts/utils/launchagents.sh" "${labels[@]}"

--- a/home/.chezmoiscripts/run_onchange_after_50-launchagents.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_50-launchagents.sh.tmpl
@@ -7,7 +7,9 @@
 # load it — only `launchctl bootstrap` does. run_onchange re-fires whenever the
 # plist source or the script changes.
 #
-# Plist source hash: {{ include "Library/LaunchAgents/net.aaroncurry.motherbox.nightly-maintenance.plist.tmpl" | sha256sum }}
+# Nightly plist hash: {{ includeTemplate "Library/LaunchAgents/net.aaroncurry.motherbox.nightly-maintenance.plist.tmpl" . | sha256sum }}
+# Obsidian Sync plist hash: {{ includeTemplate "Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist.tmpl" . | sha256sum }}
+# Obsidian Sync runner hash: {{ include (joinPath .chezmoi.workingTree "scripts/apps/obsidian/sync.sh") | sha256sum }}
 # Script hash: {{ include (joinPath .chezmoi.workingTree "scripts/utils/launchagents.sh") | sha256sum }}
 set -euo pipefail
 

--- a/home/.chezmoiscripts/run_onchange_after_50-launchagents.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_50-launchagents.sh.tmpl
@@ -8,8 +8,10 @@
 # plist source or the script changes.
 #
 # Nightly plist hash: {{ includeTemplate "Library/LaunchAgents/net.aaroncurry.motherbox.nightly-maintenance.plist.tmpl" . | sha256sum }}
+{{ if and (eq .profile "personal") (eq .machine "mini") }}
 # Obsidian Sync plist hash: {{ includeTemplate "Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist.tmpl" . | sha256sum }}
 # Obsidian Sync runner hash: {{ include (joinPath .chezmoi.workingTree "scripts/apps/obsidian/sync.sh") | sha256sum }}
+{{ end }}
 # Script hash: {{ include (joinPath .chezmoi.workingTree "scripts/utils/launchagents.sh") | sha256sum }}
 set -euo pipefail
 

--- a/home/Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist.tmpl
+++ b/home/Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist.tmpl
@@ -13,7 +13,7 @@
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:{{ .chezmoi.homeDir }}/.local/bin</string>
+		<string>{{ .chezmoi.homeDir }}/.local/share/mise/shims:/usr/bin:/bin:/usr/sbin:/sbin</string>
 	</dict>
 
 	<key>RunAtLoad</key>

--- a/home/Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist.tmpl
+++ b/home/Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist.tmpl
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>net.aaroncurry.motherbox.obsidian-sync</string>
+
+	<key>ProgramArguments</key>
+	<array>
+		<string>{{ .chezmoi.workingTree }}/scripts/apps/obsidian/sync.sh</string>
+	</array>
+
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:{{ .chezmoi.homeDir }}/.local/bin</string>
+	</dict>
+
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>ThrottleInterval</key>
+	<integer>30</integer>
+</dict>
+</plist>

--- a/home/Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist.tmpl
+++ b/home/Library/LaunchAgents/net.aaroncurry.motherbox.obsidian-sync.plist.tmpl
@@ -1,3 +1,4 @@
+{{- if and (eq .profile "personal") (eq .machine "mini") -}}
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -24,3 +25,4 @@
 	<integer>30</integer>
 </dict>
 </plist>
+{{- end -}}

--- a/home/dot_config/motherbox/executable_maintenance.sh.tmpl
+++ b/home/dot_config/motherbox/executable_maintenance.sh.tmpl
@@ -8,10 +8,24 @@ set -uo pipefail
 
 REPO="{{ .chezmoi.workingTree }}"
 
+{{ if and (eq .profile "personal") (eq .machine "mini") }}
+ensure_obsidian_sync_loaded() {
+    local label="net.aaroncurry.motherbox.obsidian-sync"
+    local service="gui/${UID}/${label}"
+
+    if launchctl print "$service" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    echo "==> Obsidian Headless Sync is not loaded; reloading it"
+    "$REPO/scripts/utils/launchagents.sh" "$label"
+}
+{{ end }}
+
 run_nightly() {
     "$REPO/scripts/bin/motherbox-status" --quiet
 {{ if and (eq .profile "personal") (eq .machine "mini") }}
-    "$REPO/scripts/apps/obsidian/sync.sh"
+    ensure_obsidian_sync_loaded
     "$REPO/scripts/apps/claude-desktop/restart.sh"
 {{ end }}
 }

--- a/home/dot_config/motherbox/executable_maintenance.sh.tmpl
+++ b/home/dot_config/motherbox/executable_maintenance.sh.tmpl
@@ -8,24 +8,23 @@ set -uo pipefail
 
 REPO="{{ .chezmoi.workingTree }}"
 
-{{ if and (eq .profile "personal") (eq .machine "mini") }}
-ensure_obsidian_sync_loaded() {
-    local label="net.aaroncurry.motherbox.obsidian-sync"
-    local service="gui/${UID}/${label}"
+ensure_launchagents_loaded() {
+    local label service
+    for label in "$@"; do
+        service="gui/${UID}/${label}"
+        if launchctl print "$service" >/dev/null 2>&1; then
+            continue
+        fi
 
-    if launchctl print "$service" >/dev/null 2>&1; then
-        return 0
-    fi
-
-    echo "==> Obsidian Headless Sync is not loaded; reloading it"
-    "$REPO/scripts/utils/launchagents.sh" "$label"
+        echo "==> launchd: $label is not loaded; reloading it"
+        "$REPO/scripts/utils/launchagents.sh" "$label"
+    done
 }
-{{ end }}
 
 run_nightly() {
     "$REPO/scripts/bin/motherbox-status" --quiet
 {{ if and (eq .profile "personal") (eq .machine "mini") }}
-    ensure_obsidian_sync_loaded
+    ensure_launchagents_loaded net.aaroncurry.motherbox.obsidian-sync
     "$REPO/scripts/apps/claude-desktop/restart.sh"
 {{ end }}
 }

--- a/scripts/apps/obsidian/sync.sh
+++ b/scripts/apps/obsidian/sync.sh
@@ -38,15 +38,14 @@ if [[ ! -d "$VAULT/.obsidian" ]]; then
     exit 1
 fi
 
-if ! command -v mise >/dev/null 2>&1; then
-    printf 'mise is required to run the managed obsidian-headless CLI\n' >&2
+if ! command -v ob >/dev/null 2>&1; then
+    printf 'The managed obsidian-headless CLI was not found on PATH\n' >&2
     exit 1
 fi
 
-mise exec -- ob sync-config \
+ob sync-config \
     --path "$VAULT" \
     --mode bidirectional \
-    --configs "" \
-    --device-name "Motherbox headless"
+    --configs ""
 
-exec mise exec -- ob sync --path "$VAULT" --continuous
+exec ob sync --path "$VAULT" --continuous

--- a/scripts/apps/obsidian/sync.sh
+++ b/scripts/apps/obsidian/sync.sh
@@ -1,13 +1,52 @@
 #!/bin/bash
-# Sync the Obsidian vault headlessly. Obsidian holds a lock on the vault while
-# running, so quit it first.
+# Keep the Memex vault synchronized with Obsidian Sync.
 #
-# Requires a one-time login per machine:
+# Requires one-time setup on the Mac mini:
 #   ob login
 #   ob sync-setup --vault Memex --path ~/Notes/Memex
 set -euo pipefail
 
-REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+VAULT="$HOME/Notes/Memex"
 
-osascript "$REPO/scripts/utils/quit-obsidian.applescript"
-ob sync --path ~/Notes/Memex
+show_help() {
+    cat <<'EOF'
+Usage: sync.sh [--help]
+
+Run continuous bidirectional Obsidian Headless Sync for ~/Notes/Memex.
+Configuration sync is disabled so Obsidian Desktop can use the same local
+folder without Headless Sync changing its plugins or settings. Desktop's Sync
+core plugin must remain disabled on this Mac.
+EOF
+}
+
+case "${1:-}" in
+-h | --help | help)
+    show_help
+    exit 0
+    ;;
+"") ;;
+*)
+    printf "Unknown option: %s\n\n" "$1" >&2
+    show_help
+    exit 1
+    ;;
+esac
+
+if [[ ! -d "$VAULT/.obsidian" ]]; then
+    printf 'Obsidian vault is not configured at %s\n' "$VAULT" >&2
+    printf 'Run: mise exec -- ob sync-setup --vault Memex --path %s\n' "$VAULT" >&2
+    exit 1
+fi
+
+if ! command -v mise >/dev/null 2>&1; then
+    printf 'mise is required to run the managed obsidian-headless CLI\n' >&2
+    exit 1
+fi
+
+mise exec -- ob sync-config \
+    --path "$VAULT" \
+    --mode bidirectional \
+    --configs "" \
+    --device-name "Mac mini headless"
+
+exec mise exec -- ob sync --path "$VAULT" --continuous

--- a/scripts/apps/obsidian/sync.sh
+++ b/scripts/apps/obsidian/sync.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Keep the Memex vault synchronized with Obsidian Sync.
 #
-# Requires one-time setup on the Mac mini:
+# Requires one-time setup:
 #   ob login
 #   ob sync-setup --vault Memex --path ~/Notes/Memex
 set -euo pipefail
@@ -15,7 +15,7 @@ Usage: sync.sh [--help]
 Run continuous bidirectional Obsidian Headless Sync for ~/Notes/Memex.
 Configuration sync is disabled so Obsidian Desktop can use the same local
 folder without Headless Sync changing its plugins or settings. Desktop's Sync
-core plugin must remain disabled on this Mac.
+core plugin must remain disabled wherever this runner is active.
 EOF
 }
 
@@ -34,7 +34,7 @@ esac
 
 if [[ ! -d "$VAULT/.obsidian" ]]; then
     printf 'Obsidian vault is not configured at %s\n' "$VAULT" >&2
-    printf 'Run: mise exec -- ob sync-setup --vault Memex --path %s\n' "$VAULT" >&2
+    printf 'Run: ob sync-setup --vault Memex --path %s\n' "$VAULT" >&2
     exit 1
 fi
 
@@ -47,6 +47,6 @@ mise exec -- ob sync-config \
     --path "$VAULT" \
     --mode bidirectional \
     --configs "" \
-    --device-name "Mac mini headless"
+    --device-name "Motherbox headless"
 
 exec mise exec -- ob sync --path "$VAULT" --continuous

--- a/scripts/apps/obsidian/sync.sh
+++ b/scripts/apps/obsidian/sync.sh
@@ -13,9 +13,8 @@ show_help() {
 Usage: sync.sh [--help]
 
 Run continuous bidirectional Obsidian Headless Sync for ~/Notes/Memex.
-Configuration sync is disabled so Obsidian Desktop can use the same local
-folder without Headless Sync changing its plugins or settings. Desktop's Sync
-core plugin must remain disabled wherever this runner is active.
+Obsidian Desktop's Sync core plugin must remain disabled wherever this runner
+is active.
 EOF
 }
 
@@ -42,10 +41,5 @@ if ! command -v ob >/dev/null 2>&1; then
     printf 'The managed obsidian-headless CLI was not found on PATH\n' >&2
     exit 1
 fi
-
-ob sync-config \
-    --path "$VAULT" \
-    --mode bidirectional \
-    --configs ""
 
 exec ob sync --path "$VAULT" --continuous

--- a/scripts/utils/launchagents.sh
+++ b/scripts/utils/launchagents.sh
@@ -10,11 +10,11 @@ set -euo pipefail
 
 show_help() {
     cat <<'EOF'
-Usage: launchagents.sh [LABEL...] [--help]
+Usage: launchagents.sh LABEL... [--help]
 
 Reload launchd user agents: bootout (ignoring "not loaded") then bootstrap the
-matching plist in ~/Library/LaunchAgents. With no arguments, reloads every
-agent managed by this repo that applies to this machine. Idempotent.
+matching plists in ~/Library/LaunchAgents. Labels are selected by the calling
+chezmoi hook. Idempotent.
 EOF
 }
 
@@ -25,15 +25,12 @@ case "${1:-}" in
     ;;
 esac
 
-# Machine-specific plists are excluded by chezmoi where they do not apply.
-LABELS=(net.aaroncurry.motherbox.nightly-maintenance)
-obsidian_label="net.aaroncurry.motherbox.obsidian-sync"
-if [[ -f "$HOME/Library/LaunchAgents/${obsidian_label}.plist" ]]; then
-    LABELS+=("$obsidian_label")
+if [[ $# -eq 0 ]]; then
+    show_help >&2
+    exit 1
 fi
-if [[ $# -gt 0 ]]; then
-    LABELS=("$@")
-fi
+
+LABELS=("$@")
 
 uid=$(id -u)
 for label in "${LABELS[@]}"; do

--- a/scripts/utils/launchagents.sh
+++ b/scripts/utils/launchagents.sh
@@ -14,7 +14,7 @@ Usage: launchagents.sh [LABEL...] [--help]
 
 Reload launchd user agents: bootout (ignoring "not loaded") then bootstrap the
 matching plist in ~/Library/LaunchAgents. With no arguments, reloads every
-agent managed by this repo. Idempotent.
+agent managed by this repo that applies to this machine. Idempotent.
 EOF
 }
 
@@ -25,9 +25,12 @@ case "${1:-}" in
     ;;
 esac
 
-# The agents this repo manages. Each runs on every machine; the job itself
-# branches on the machine name the plist passes it.
+# Machine-specific plists are excluded by chezmoi where they do not apply.
 LABELS=(net.aaroncurry.motherbox.nightly-maintenance)
+obsidian_label="net.aaroncurry.motherbox.obsidian-sync"
+if [[ -f "$HOME/Library/LaunchAgents/${obsidian_label}.plist" ]]; then
+    LABELS+=("$obsidian_label")
+fi
 if [[ $# -gt 0 ]]; then
     LABELS=("$@")
 fi


### PR DESCRIPTION
## Problem

The Mac mini's Obsidian MCP reads the local vault directly, but Motherbox only ran a nightly one-shot Headless Sync and quit Obsidian Desktop first. MCP writes could therefore sit unsynced, and Desktop could not remain open for local work.

## Solution

Run one Mini-only continuous, bidirectional Obsidian Headless Sync process under launchd, with configuration sync disabled. KeepAlive handles process exits, nightly maintenance repairs an unloaded job, and the setup notes require Desktop Sync to remain disabled while still allowing Desktop to edit the same local vault.
